### PR TITLE
Fixed gobber ingot item IDs.

### DIFF
--- a/src/main/resources/data/c/tags/items/gobber_nether_ingots.json
+++ b/src/main/resources/data/c/tags/items/gobber_nether_ingots.json
@@ -2,7 +2,7 @@
   "replace": false,
   "values": [
     {
-      "id": "gobber2:gobber_ingot_nether",
+      "id": "gobber2:gobber2_ingot_nether",
       "required": false
     }
   ]


### PR DESCRIPTION
"gobber_ingot(_xxx)" => "gobber2_ingot(_xxx)".